### PR TITLE
fix(ci): sync uv.lock in release PR + use logging.exception

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,3 +27,30 @@ jobs:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please bumps pyproject.toml but never runs `uv lock`, so the
+      # locked project version drifts. Sync it back into the open release PR.
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up uv
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Sync uv.lock with release version
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          uv lock
+          if git diff --quiet uv.lock; then
+            echo "uv.lock already in sync"
+            exit 0
+          fi
+          git config user.name "ci-bot"
+          git config user.email "actions@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with release version"
+          git push

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Set up uv
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          python-version: '3.12'
+          enable-cache: true
 
       - name: Sync uv.lock with release version
         if: ${{ steps.release.outputs.prs_created == 'true' }}

--- a/src/devto_mirror/ai_optimization/cross_reference.py
+++ b/src/devto_mirror/ai_optimization/cross_reference.py
@@ -130,8 +130,8 @@ def add_source_attribution(post: Any, _site_config: Optional[Dict[str, str]] = N
 
         logger.debug(f"Generated source attribution for post: {getattr(post, 'slug', 'unknown')}")
 
-    except Exception as e:
-        logger.error(f"Error generating source attribution: {e}")
+    except Exception:
+        logger.exception("Error generating source attribution")
         # Provide minimal fallback attribution
         attribution_data = {
             "source_platform": DEVTO_PLATFORM,
@@ -201,8 +201,8 @@ def generate_related_links(post: Any, all_posts: List[Any], max_related: int = 5
         if related_posts:
             logger.debug(f"Found {len(related_posts)} related posts for: {getattr(post, 'slug', 'unknown')}")
 
-    except Exception as e:
-        logger.error(f"Error generating related links: {e}")
+    except Exception:
+        logger.exception("Error generating related links")
 
     return related_posts
 
@@ -261,8 +261,8 @@ def create_dev_to_backlinks(post: Any) -> Dict[str, Any]:
 
         logger.debug(f"Generated Dev.to backlinks for post: {getattr(post, 'slug', 'unknown')}")
 
-    except Exception as e:
-        logger.error(f"Error creating Dev.to backlinks: {e}")
+    except Exception:
+        logger.exception("Error creating Dev.to backlinks")
 
     return backlink_data
 
@@ -305,8 +305,8 @@ def _generate_attribution_html(canonical_url: str, author: str, date: str) -> st
 
         return attribution_html.strip()
 
-    except Exception as e:
-        logger.error(f"Error generating attribution HTML: {e}")
+    except Exception:
+        logger.exception("Error generating attribution HTML")
         return f'<p><em>Originally published on <a href="{canonical_url}">Dev.to</a></em></p>'
 
 
@@ -367,8 +367,8 @@ def _generate_backlink_html(canonical_url: str, post: Any) -> str:
 
         return backlink_html.strip()
 
-    except Exception as e:
-        logger.error(f"Error generating backlink HTML: {e}")
+    except Exception:
+        logger.exception("Error generating backlink HTML")
         return f'<p><a href="{canonical_url}">View on Dev.to</a></p>'
 
 
@@ -402,8 +402,8 @@ def enhance_post_with_cross_references(
 
         return cross_ref_data
 
-    except Exception as e:
-        logger.error(f"Error enhancing post with cross-references: {e}")
+    except Exception:
+        logger.exception("Error enhancing post with cross-references")
         return {
             "attribution": {},
             "related_posts": [],

--- a/src/devto_mirror/ai_optimization/sitemap_generator.py
+++ b/src/devto_mirror/ai_optimization/sitemap_generator.py
@@ -75,8 +75,8 @@ class DevToAISitemapGenerator:
             xml_content = self._generate_sitemap_xml(sitemap_entries)
             return xml_content
 
-        except Exception as e:
-            logger.error(f"Failed to generate main sitemap: {e}")
+        except Exception:
+            logger.exception("Failed to generate main sitemap")
             # Fallback to basic sitemap format
             return self._generate_basic_sitemap(posts, comments)
 
@@ -122,8 +122,8 @@ class DevToAISitemapGenerator:
 
             return self._generate_sitemap_xml(sitemap_entries)
 
-        except Exception as e:
-            logger.error(f"Failed to generate content sitemap: {e}")
+        except Exception:
+            logger.exception("Failed to generate content sitemap")
             return ""
 
     def generate_discovery_feed(self, posts: List[Any]) -> str:
@@ -153,8 +153,8 @@ class DevToAISitemapGenerator:
 
             return self._generate_discovery_xml(feed_entries)
 
-        except Exception as e:
-            logger.error(f"Failed to generate discovery feed: {e}")
+        except Exception:
+            logger.exception("Failed to generate discovery feed")
             return ""
 
     def _create_url_entry(


### PR DESCRIPTION
## What 🔧

Two independent fixes:

### 1. release-please leaves `uv.lock` stale
- release-please bumps `pyproject.toml` but never runs `uv lock`
- Result: locked project version drifted (`1.0.1` vs released `1.1.0`)
- Fix: guarded follow-up in `release-please.yml` checks out the release PR branch, runs `uv lock`, pushes the synced lock back into the **same PR**
- Gated on `prs_created == 'true'`; no-op when the lock already matches
- Local commits already stay synced via the `update-lockfiles` pre-commit hook — this just closes the CI gap

### 2. SonarQube S8572 (9 findings)
- `logger.error(f"...: {e}")` → `logger.exception("...")` inside `except` blocks
- Captures stack traces; drops the redundant `as e`
- Files: `ai_optimization/cross_reference.py`, `ai_optimization/sitemap_generator.py`

## Verification ✅

- `make ai-checks` — format, lint, security, complexity, tests (88.63% > 85%) all pass
- `actionlint` clean on the workflow
- `ref:` in the new checkout comes from release-please's own output (deterministic branch name), not attacker-controlled event input; `run:` block has no `${{ }}` interpolation — no injection surface

## Notes 📝

- CI lock-sync commit is authored as `ci-bot` (matches `publish.yaml` convention) and is **not GPG-signed** — it's a generated bot commit
- Suggestion (not applied): file-level `permissions` could move to job level per repo GHA conventions, but kept the diff minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)