### PR TITLE
docs: align all documentation with current code and deploy topology

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,4 +27,4 @@ Full license text: https://polyformproject.org/licenses/shield/1.0.0/
 ---
 
 This project is licensed under Polyform Shield License 1.0.0.
-For exceptions or monetization/commercialization questions, contact Ashley Childress at [human@checkmarkdevtools.dev](mailto:human@checkmarkdevtools.dev).
+For exceptions or monetization/commercialization questions, contact Ashley Childress at [anchildress1@gmail.com](mailto:anchildress1@gmail.com).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Dev.to Mirror—The Set-and-Forget AI Crawler
 
-🔗 **Live Site:** [checkmarkdevtools.github.io/devto-mirror](https://checkmarkdevtools.github.io/devto-mirror/)
+🔗 **Live Site:** [crawly.anchildress1.dev](https://crawly.anchildress1.dev)
 
-![checkmarkdevtools/devto-mirror social card: A colorful crawler](https://github.com/checkmarkdevtools/devto-mirror/blob/main/assets/new-devto-mirror-crawlies-banner.jpg)
+![anchildress1/devto-mirror social card: A colorful crawler](./assets/new-devto-mirror-crawlies-banner.jpg)
 
-This Copilot generated utility helps make your Dev.to blogs more discoverable by search engines by automatically generating and hosting a mirror site with generous `robots.txt` rules. Avoiding Dante’s DevOps and the maintenance headache. This is a simple html, no frills approach with a sitemap and robots.tx—_that's it_ (although I'm slowly working through enhancements). If you're like me and treat some comments as mini-posts, you can selectively pull in the ones that deserve their own page.
+This Copilot generated utility helps make your Dev.to blogs more discoverable by search engines by automatically generating and hosting a mirror site with generous `robots.txt` rules. Avoiding Dante's DevOps and the maintenance headache. This is a simple html, no frills approach with a sitemap and robots.txt—_that's it_ (although I'm slowly working through enhancements). If you're like me and treat some comments as mini-posts, you can selectively pull in the ones that deserve their own page.
 
 > [!NOTE]
 >
@@ -17,7 +17,7 @@ This Copilot generated utility helps make your Dev.to blogs more discoverable by
 >
 > So yeah, obvious disconnect... Also, I'm _not_ hosting a blog on my domain (I'm a backend dev; hosting a pretty blog + analytics sounds like a relaxing afternoon with Dante's DevOps. Hard pass. 🔥🫠), but I still want control of `robots.txt.`
 >
-> **Enter the five-minute ChatGPT fix:** a tiny static mirror with canonicals back to **Dev.to**—no domain, no analytics—just (practically) instantly crawlable 😉🐜.
+> **Enter the five-minute ChatGPT fix:** a tiny static mirror with canonicals back to **Dev.to**—no fuss—just (practically) instantly crawlable 😉🐜.
 >
 > P.S. "Five minutes" usually means two hours. Acceptable losses. 😅 And seriously, writing this blurb took longer than the code. 🤨 Alright.... **3 hours** (it took me an hour to get the picture just right, enough anyway) and lots of follow up work. Still worth it! 😅
 >
@@ -25,11 +25,11 @@ This Copilot generated utility helps make your Dev.to blogs more discoverable by
 
 ## Repo Stuff
 
-[![GitHub License](https://img.shields.io/badge/license-Polyform_Shield_1.0.0-yellow?style=for-the-badge)](./LICENSE) ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge) ![Repo Size](https://img.shields.io/github/repo-size/checkmarkdevtools/devto-mirror?style=for-the-badge) ![Last Commit](https://img.shields.io/github/last-commit/checkmarkdevtools/devto-mirror?style=for-the-badge)
+[![GitHub License](https://img.shields.io/badge/license-Polyform_Shield_1.0.0-yellow?style=for-the-badge)](./LICENSE) ![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg?style=for-the-badge) ![Repo Size](https://img.shields.io/github/repo-size/anchildress1/devto-mirror?style=for-the-badge) ![Last Commit](https://img.shields.io/github/last-commit/anchildress1/devto-mirror?style=for-the-badge)
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/checkmarkdevtools/devto-mirror/publish.yaml?branch=main&style=for-the-badge&logo=github&logoColor=fff&label=Publish%20Dev.to%20Mirror%20Site)](https://github.com/anchildress1/devto-mirror/actions/workflows/publish.yaml) [![CodeQL Analysis](https://img.shields.io/github/actions/workflow/status/checkmarkdevtools/devto-mirror/codeql.yml?branch=main&style=for-the-badge&logo=github&logoColor=fff&label=CodeQL%20Analysis)](https://github.com/anchildress1/devto-mirror/actions/workflows/codeql.yml) [![Security and Lint CI](https://img.shields.io/github/actions/workflow/status/checkmarkdevtools/devto-mirror/security-ci.yml?branch=main&style=for-the-badge&logo=github&logoColor=fff&label=Security%20and%20Quality%20CI)](https://github.com/checkmarkdevtools/devto-mirror/actions/workflows/security-ci.yml)
+[![Publish Dev.to Mirror Site](https://img.shields.io/github/actions/workflow/status/anchildress1/devto-mirror/publish.yaml?branch=main&style=for-the-badge&logo=github&logoColor=fff&label=Publish%20Dev.to%20Mirror%20Site)](https://github.com/anchildress1/devto-mirror/actions/workflows/publish.yaml) [![CodeQL Analysis](https://img.shields.io/github/actions/workflow/status/anchildress1/devto-mirror/codeql.yml?branch=main&style=for-the-badge&logo=github&logoColor=fff&label=CodeQL%20Analysis)](https://github.com/anchildress1/devto-mirror/actions/workflows/codeql.yml) [![Security and Quality CI](https://img.shields.io/github/actions/workflow/status/anchildress1/devto-mirror/security-ci.yml?style=for-the-badge&logo=github&logoColor=fff&label=Security%20and%20Quality%20CI)](https://github.com/anchildress1/devto-mirror/actions/workflows/security-ci.yml)
 
-![Python Badge](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcheckmarkdevtools%2Fdevto-mirror%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&query=%24.project.requires-python&style=for-the-badge&logo=python&logoColor=fff&label=Python&color=3776AB) ![uv Badge](https://img.shields.io/badge/uv-DE5FE9?logo=uv&logoColor=fff&style=for-the-badge) ![Jinja Badge](https://img.shields.io/badge/Jinja-7E0C1B?logo=jinja&logoColor=fff&style=for-the-badge) ![GitHub Actions Badge](https://img.shields.io/badge/GitHub%20Actions-2088FF?logo=githubactions&logoColor=fff&style=for-the-badge) ![GitHub Pages Badge](https://img.shields.io/badge/GitHub%20Pages-222?logo=githubpages&logoColor=fff&style=for-the-badge)
+![Python Badge](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fanchildress1%2Fdevto-mirror%2Frefs%2Fheads%2Fmain%2Fpyproject.toml&query=%24.project.requires-python&style=for-the-badge&logo=python&logoColor=fff&label=Python&color=3776AB) ![uv Badge](https://img.shields.io/badge/uv-DE5FE9?logo=uv&logoColor=fff&style=for-the-badge) ![Jinja Badge](https://img.shields.io/badge/Jinja-7E0C1B?logo=jinja&logoColor=fff&style=for-the-badge) ![GitHub Actions Badge](https://img.shields.io/badge/GitHub%20Actions-2088FF?logo=githubactions&logoColor=fff&style=for-the-badge) ![Firebase Hosting Badge](https://img.shields.io/badge/Firebase%20Hosting-FFCA28?logo=firebase&logoColor=000&style=for-the-badge) ![GitHub Pages Badge](https://img.shields.io/badge/GitHub%20Pages-222?logo=githubpages&logoColor=fff&style=for-the-badge)
 
 ![Verdent Badge](https://img.shields.io/badge/Verdent-00D486?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyByb2xlPSJpbWciIHZpZXdCb3g9IjAgMCAzMiAzMiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48dGl0bGU+VmVyZGVudDwvdGl0bGU+CjxwYXRoIGQ9Ik0xNy42IDkuOUMxNy42IDEyLjEgMTYuOCAxNC4yIDE1LjQgMTUuN0wxNS4xIDE2QzEzLjcgMTcuNSAxMi44IDE5LjYgMTIuOCAyMS44QzEyLjggMjIuNSAxMi45IDIzLjIgMTMuMSAyMy45QzEwLjcgMjIuOSA4LjggMjAuOSA4IDE4LjRDNy44IDE3LjYgNy43IDE2LjggNy43IDE2QzcuNyAxMy44IDguNSAxMS44IDkuOCAxMC4zTDE1LjMgNEMxNi4yIDUgMTYuOSA2LjEgMTcuMyA3LjVDMTcuNSA4LjIgMTcuNiA5IDE3LjYgOS45WiIgZmlsbD0iI2ZmZmZmZiIvPgo8cGF0aCBkPSJNMTQuMyAyMi43QzE0LjMgMjAuNSAxNS4xIDE4LjQgMTYuNSAxNi45TDE2LjggMTYuNkMxOC4yIDE1LjEgMTkuMSAxMyAxOS4xIDEwLjhDMTkuMSAxMCAxOSA5LjQgMTguOCA4LjdDMjEuMiA5LjcgMjMuMSAxMS43IDIzLjkgMTQuMkMyNCAxNSAyNC4yIDE1LjggMjQuMiAxNi42QzI0LjIgMTguOCAyMy40IDIwLjggMjIuMSAyMi4zTDE2LjYgMjguNkMxNS43IDI3LjYgMTUgMjYuNSAxNC42IDI1LjFDMTQuNCAyNC4zIDE0LjMgMjMuNSAxNC4zIDIyLjdaIiBmaWxsPSIjZmZmZmZmIi8+Cjwvc3ZnPg==) ![GitHub Copilot Badge](https://img.shields.io/badge/GitHub%20Copilot-000?logo=githubcopilot&logoColor=fff&style=for-the-badge)
 
@@ -37,74 +37,186 @@ This Copilot generated utility helps make your Dev.to blogs more discoverable by
 
  [![BuyMeACoffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/anchildress1) [![dev.to Badge](https://img.shields.io/badge/dev.to-0A0A0A?logo=devdotto&logoColor=fff&style=for-the-badge)](https://dev.to/anchildress1) [![LinkedIn](https://img.shields.io/badge/LinkedIn-%230077B5.svg?logo=linkedin\&logoColor=white&style=for-the-badge)](https://www.linkedin.com/in/anchildress1/) [![Medium](https://img.shields.io/badge/Medium-000?logo=medium&logoColor=fff&style=for-the-badge)](https://medium.com/@anchildress1) [![Reddit Badge](https://img.shields.io/badge/Reddit-FF4500?logo=reddit&logoColor=fff&style=for-the-badge)](https://www.reddit.com/user/anchildress1/)
 
+---
+
 ## What is this?
 
-Auto-generates a static mirror of your Dev.to blog with generous `robots.txt` for AI crawlers. Simple HTML, sitemap, canonical links—zero maintenance.
+Auto-generates a static mirror of your Dev.to blog with a generous `robots.txt` for AI crawlers. Plain HTML, sitemap, canonical links back to Dev.to—zero maintenance. Every page is enriched with JSON-LD structured data and cross-reference metadata so search engines and LLMs can actually parse it.
+
+It runs on a schedule, fetches only what changed since last time, and deploys itself. You set two repo variables and walk away.
+
+---
+
+## Tech Stack
+
+| Layer | What's used |
+| --- | --- |
+| Language | Python **3.12+** |
+| Package manager | [`uv`](https://docs.astral.sh/uv/) (locked, reproducible) |
+| Templating | Jinja2 → static HTML |
+| Content safety | `bleach` HTML sanitization |
+| Upstream deploy | **Firebase Hosting** (keyless, via Workload Identity Federation) |
+| Fork deploy | **GitHub Pages** (`gh-pages` branch) |
+| CI/CD | GitHub Actions (composite action shared by both deploy paths) |
+| Analytics (optional) | Firebase Analytics (GA4), opt-in via `FIREBASE_WEB_CONFIG` |
+| Quality gates | Black, flake8, isort, bandit, pip-audit, detect-secrets, radon, Lefthook |
+
+---
+
+## Architecture
+
+One generation pipeline, two deploy targets. The upstream repo (owner `anchildress1`) ships to Firebase; **forks ship to GitHub Pages**. A shared composite action guarantees both produce identical output, and incremental state lives on a separate branch from the deployed site.
+
+```mermaid
+flowchart TD
+    accTitle: Dev.to Mirror build and deploy pipeline
+    accDescr: Posts are fetched incrementally from the Dev.to API, rendered to static HTML by the generator and renderer modules, assembled by a shared composite action, then deployed to Firebase Hosting on the upstream repo or to GitHub Pages on forks, with incremental state stored on separate branches.
+
+    devto([Dev.to API]) -->|incremental fetch via last_run.txt| gen[generator module]
+    gen -->|AI optimization: JSON-LD, cross-refs, metadata| art[/posts/*.html, index.html, sitemap.xml, posts_data.json/]
+    ren[renderer module] -->|re-render index + sitemap| art
+    art --> action[generate-site composite action]
+    action --> pub[publish.yaml — upstream only]
+    action --> ghp[deploy-gh-pages.yml — forks]
+    pub -->|WIF / OIDC keyless auth| fb[Firebase Hosting<br/>crawly.anchildress1.dev]
+    ghp --> pages[GitHub Pages<br/>username.github.io/devto-mirror]
+    pub -.incremental state.-> ms[(mirror-state branch)]
+    ghp -.incremental state.-> gp[(gh-pages branch)]
+```
+
+---
 
 ## Quick Setup ⚡
 
-1. **Fork** this repo
-2. **Set variables** (Settings → Actions → Variables):
-  - `DEVTO_USERNAME` – your Dev.to username
-  - `SITE_DOMAIN` – (optional) custom domain like `crawly.checkmarkdevtools.dev`
-  - `GH_USERNAME` – your GitHub username (required if not using custom domain)
-3. **(Optional) Set API key** (Settings → Actions → Secrets):
-  - `DEVTO_KEY` – for private/draft posts
-4. **Delete** `gh-pages` branch if it exists
-5. **Update** `comments.txt` file (or delete it completely)
-6. **Run workflow** Actions → **Deploy Dev.to Mirror to GitHub Pages** → Run workflow
-7. **Enable Pages** → Settings → Pages → Deploy from branch → `gh-pages`
+These steps cover the **fork path** (GitHub Pages)—what almost everyone wants. The Firebase path is upstream-only; see [Configuration](#configuration) for those extras.
 
-This will automatically pull new content from Dev every **Wednesday at 9:40 AM EST**.
+1. **Fork** this repo.
+2. **Set repository variables** (Settings → Secrets and variables → Actions → Variables):
+   - `DEVTO_USERNAME` – your Dev.to username
+   - `GH_USERNAME` – your GitHub username (required unless you set a custom domain)
+   - `SITE_DOMAIN` – _(optional)_ custom domain like `crawly.anchildress1.dev`
+3. **(Optional) Set a secret** (same page → Secrets):
+   - `DEVTO_KEY` – only needed for private/draft posts
+4. **Update** `comments.txt` to pick which comments become standalone pages (or delete it).
+5. **Run the workflow**: Actions → **Deploy Dev.to Mirror to GitHub Pages** → Run workflow. This creates the `gh-pages` branch.
+6. **Enable Pages**: Settings → Pages → Deploy from a branch → `gh-pages`.
+
+After that it pulls new content automatically every **Wednesday at 14:40 UTC** (≈09:40 ET in winter, 10:40 ET during DST).
 
 > [!IMPORTANT]
-> Forks publish to GitHub Pages via the `deploy-gh-pages.yml` workflow, with incremental state riding along on the `gh-pages` branch. The upstream repo deploys to Firebase Hosting (`publish.yaml`) and keeps its state on a separate `mirror-state` branch. Deploying with a `gh-pages` branch is somewhat deprecated, but it was the most straightforward way to keep a running history. To force a complete refresh, trigger the workflow with the `force_full_regen` option.
+> Forks publish to GitHub Pages via `deploy-gh-pages.yml`, with incremental state riding along on the `gh-pages` branch. The upstream repo deploys to **Firebase Hosting** (`publish.yaml`) and keeps its state on a separate `mirror-state` branch. To force a complete refresh, trigger the workflow with the `force_full_regen` option.
+
+---
+
+## Configuration
+
+Everything is driven by repository variables and secrets—no config files to edit.
+
+### Everyone (fork or upstream)
+
+| Name | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `DEVTO_USERNAME` | Variable | ✅ | Dev.to profile to mirror |
+| `GH_USERNAME` | Variable | ✅ (unless `SITE_DOMAIN` set) | Builds the GitHub Pages URL |
+| `SITE_DOMAIN` | Variable | optional | Custom domain; overrides the Pages/Firebase URL |
+| `DEVTO_KEY` | Secret | optional | Dev.to API key—only for private/draft posts |
+
+### Upstream-only (Firebase deploy)
+
+| Name | Type | Required | Purpose |
+| --- | --- | --- | --- |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Variable | ✅ for Firebase | Full WIF provider resource name (keyless auth) |
+| `GCP_DEPLOY_SERVICE_ACCOUNT` | Variable | ✅ for Firebase | Deploy SA email (needs `roles/firebasehosting.admin`) |
+| `FIREBASE_PROJECT_ID` | Variable | optional | Firebase project id (defaults to `anchildress1`) |
+| `FIREBASE_WEB_CONFIG` | Variable | optional | Firebase web config JSON; enables **opt-in** GA4 Analytics when set |
+
+> [!NOTE]
+> The Firebase web config is **public by design**—it's safe as a plain repo variable, not a secret. Analytics stays dormant until `FIREBASE_WEB_CONFIG` is set, so forks ship zero tracking.
+
+---
 
 ## How it works
 
-Fetches posts via Dev.to API (incremental updates via `last_run.txt`). Generates **plain HTML** files with canonical links back to Dev.to, AI-specific optimizations, plus sitemap and robots.txt. Optional: include comments as standalone pages via `comments.txt` or delete it entirely.
+Fetches posts via the Dev.to API (incremental updates tracked in `last_run.txt`), then generates **plain HTML** with canonical links back to Dev.to, AI-specific structured data, plus `sitemap.xml` and `robots.txt`. Optionally renders selected comments as standalone pages via `comments.txt`.
 
-**Force full regeneration:** Actions → **Deploy Dev.to Mirror to GitHub Pages** → Run workflow with `force_full_regen: true`.
+- **`generator`** (`python -m devto_mirror.site_generation.generator`) — the main pipeline: fetch → merge → dedupe → write `posts/*.html`, `index.html`, `sitemap.xml`, `posts_data.json`, plus AI cross-references and JSON-LD.
+- **`renderer`** (`python -m devto_mirror.site_generation.renderer`) — re-renders `index.html` and `sitemap.xml` from the cached `posts_data.json`.
+
+**Force full regeneration:** trigger either deploy workflow with `force_full_regen: true`.
 
 > [!WARNING]
-> I've tinkered some with moving `robots.txt` and `llms.txt` to the base-level repo, but haven't been able to make it work yet. Research says it's possible, but I'm either doing it all wrong *or* AI lied to me. 🤷‍♀️ So, the [Google Search Console](https://search.google.com/search-console) have a difficult time locating these files currently. Otherwise, there doesn't seem to be any problems with keeping those files here.
+> Root-level `robots.txt` / `llms.txt` (served from `username.github.io` rather than the project path) isn't wired up yet. [Google Search Console](https://search.google.com/search-console) can have trouble finding them at the project path. If you need root-level crawler files, copy `robots.txt` and `llms.txt` into your root user/org Pages repo manually.
+
+---
+
+## Project Structure
+
+```plaintext
+devto-mirror/
+├── src/devto_mirror/
+│   ├── core/              # Dev.to API client, HTML sanitization, URL building,
+│   │                      #   run-state, shared Jinja templates + Firebase Analytics
+│   ├── ai_optimization/   # JSON-LD schemas, metadata enhancement, cross-references,
+│   │                      #   AI-friendly sitemap generation
+│   ├── site_generation/   # generator.py (main pipeline) + renderer.py (index/sitemap)
+│   ├── templates/         # post_template.html
+│   └── tools/             # one-off maintenance helpers (clean_posts, fix_slugs, ...)
+├── scripts/               # CI helpers (validate_site_generation, check_detect_secrets, run_pip_audit)
+├── tests/                 # unittest suite (85% coverage gate)
+├── assets/                # banner, robots.txt, llms.txt
+├── .github/
+│   ├── workflows/         # publish.yaml (Firebase), deploy-gh-pages.yml (forks),
+│   │                      #   codeql.yml, security-ci.yml, release-please.yml
+│   └── actions/generate-site/   # composite action shared by both deploy workflows
+├── docs/                  # deep-dive guides (start at docs/README.md)
+├── Makefile               # make install / ai-checks / test / ...
+├── pyproject.toml         # dependencies (managed by uv)
+└── lefthook.yml           # pre-commit + pre-push git hooks
+```
+
+---
 
 ## Local Development
 
 ```bash
-git clone https://github.com/checkmarkdevtools/devto-mirror.git
+git clone https://github.com/anchildress1/devto-mirror.git
 cd devto-mirror
 
 # Install uv if you don't have it
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Or update to latest version
-uv self --no-python-downloads update
-
-# Install dependencies and lefthook hooks
+# Install dependencies and Lefthook git hooks
 make install
 
 # Configure environment
 cp .env.example .env
 # Edit .env with your DEVTO_USERNAME and GH_USERNAME
 
-# Run validation
+# Generate the site locally
+uv run python -m devto_mirror.site_generation.generator
+
+# Run the full validation suite (format, lint, security, complexity, tests)
 make ai-checks
 ```
 
+`make install` wires up Lefthook so `pre-commit` (format, lint, security) and `pre-push` (tests, complexity, site validation) run automatically. Full details in the [Development Guide](./docs/DEV_GUIDE.md).
+
+---
+
 ## Documentation 📚
 
-Additional documentation is available in the [`docs/`](./docs/) directory:
+Deep-dive docs live in [`docs/`](./docs/) (index: [`docs/README.md`](./docs/README.md)):
 
-- [Development Guide](./docs/DEV_GUIDE.md) - Local development setup and commands
-- [CI/CD Guide](./docs/CI_GUIDE.md) - GitHub Actions workflows and deployment
-- [Security Analysis](./docs/SECURITY_ANALYSIS.md) - Security recommendations and workflows
-- [Migration Plan](./docs/MIGRATION_PLAN.md) - AI optimization refactoring progress
+- [Development Guide](./docs/DEV_GUIDE.md) — local setup, environment variables, validation pipeline
+- [CI/CD Guide](./docs/CI_GUIDE.md) — workflow architecture, Firebase + Pages deploy paths
+- [Security Analysis](./docs/SECURITY_ANALYSIS.md) — security posture and recommendations
+
+---
 
 ## License 📄
 
 Every project has to have a stack of fine print somewhere. _Keep going, keep going, keep going..._ Here's mine, as painless as possible:
 
-You know where [the license](./LICENSE) is, but I'll sum it up: **this is not open source** (even though you can still do just about anything you want with it). As long as you're not turning it into the next big SaaS or selling subscriptions in the cloud, then have fun! Else, **you've gotta ask me first.**
+You know where [the license](./LICENSE) is, but I'll sum it up: **this is not open source** (even though you can still do just about anything you want with it). It's [Polyform Shield 1.0.0](./LICENSE)—as long as you're not turning it into the next big SaaS or selling subscriptions in the cloud, then have fun! Else, **you've gotta ask me first.**
 
 Basically? This project's got boundaries. Be cool, don't try to sneak it into a product launch, and we'll get along just fine. 😘

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It runs on a schedule, fetches only what changed since last time, and deploys it
 
 ## Architecture
 
-One generation pipeline, two deploy targets. The upstream repo (owner `anchildress1`) ships to Firebase; **forks ship to GitHub Pages**. A shared composite action guarantees both produce identical output, and incremental state lives on a separate branch from the deployed site.
+One generation pipeline, two deploy targets. The upstream repo (owner `anchildress1`) ships to Firebase; **forks ship to GitHub Pages**. A shared composite action guarantees both produce identical output. Incremental state lives on a dedicated branch — kept apart from the deploy upstream (the `mirror-state` branch), and alongside the site on `gh-pages` for forks.
 
 ```mermaid
 flowchart TD
@@ -73,7 +73,7 @@ flowchart TD
     accDescr: Posts are fetched incrementally from the Dev.to API, rendered to static HTML by the generator and renderer modules, assembled by a shared composite action, then deployed to Firebase Hosting on the upstream repo or to GitHub Pages on forks, with incremental state stored on separate branches.
 
     devto([Dev.to API]) -->|incremental fetch via last_run.txt| gen[generator module]
-    gen -->|AI optimization: JSON-LD, cross-refs, metadata| art[/posts/*.html, index.html, sitemap.xml, posts_data.json/]
+    gen -->|AI optimization: JSON-LD, cross-refs, metadata| art[/"posts/*.html, index.html, sitemap.xml, posts_data.json"/]
     ren[renderer module] -->|re-render index + sitemap| art
     art --> action[generate-site composite action]
     action --> pub[publish.yaml — upstream only]
@@ -97,9 +97,10 @@ These steps cover the **fork path** (GitHub Pages)—what almost everyone wants.
    - `SITE_DOMAIN` – _(optional)_ custom domain like `crawly.anchildress1.dev`
 3. **(Optional) Set a secret** (same page → Secrets):
    - `DEVTO_KEY` – only needed for private/draft posts
-4. **Update** `comments.txt` to pick which comments become standalone pages (or delete it).
-5. **Run the workflow**: Actions → **Deploy Dev.to Mirror to GitHub Pages** → Run workflow. This creates the `gh-pages` branch.
-6. **Enable Pages**: Settings → Pages → Deploy from a branch → `gh-pages`.
+4. **Delete the inherited `gh-pages` branch** if your fork copied one from upstream. Forks inherit upstream's branches, so a leftover `gh-pages` carries upstream's `last_run.txt`/`posts_data.json` — the first run would restore that state, skip your older posts, and keep publishing stale upstream content (the deploy uses `keep_files: true`). Start clean.
+5. **Update** `comments.txt` to pick which comments become standalone pages (or delete it).
+6. **Run the workflow**: Actions → **Deploy Dev.to Mirror to GitHub Pages** → Run workflow. This recreates the `gh-pages` branch.
+7. **Enable Pages**: Settings → Pages → Deploy from a branch → `gh-pages`.
 
 After that it pulls new content automatically every **Wednesday at 14:40 UTC** (≈09:40 ET in winter, 10:40 ET during DST).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 > 🦄 “It’s not a bug, it’s an impromptu feature demo.”
 >—A developer, probably. Hopefully not me.
 
-Hey. I'm Ashley—the one and only human behind this repo (and all the others here or with the CheckMarK name on them). If you’ve stumbled across something security-related—a leak, a loophole, a weird edge case with evil vibes—thank you. I want to hear about it.
+Hey. I'm Ashley—the one and only human behind this repo (and most of the others around here). If you’ve stumbled across something security-related—a leak, a loophole, a weird edge case with evil vibes—thank you. I want to hear about it.
 
 ## 🚨 What Counts as a Security Issue?
 
@@ -26,7 +26,7 @@ Things that *don’t* count (but I admire your curiosity):
 
 Instead, email me directly at:
 
-**✉️ [human@checkmarkdevtools.dev](mailto:human@checkmarkdevtools.dev)**
+**✉️ [anchildress1@gmail.com](mailto:anchildress1@gmail.com)**
 
 Include:
 - What you found
@@ -47,5 +47,5 @@ I’ll read it. I’ll fix it. I might even send back a thank-you gif (no promis
 Thanks for keeping the chaos constructive. 🫶
 
 — Ashley
-[CheckMarK DevTools](https://checkmarkdevtools.dev)
-[human@checkmarkdevtools.dev](mailto:human@checkmarkdevtools.dev)
+[github.com/anchildress1](https://github.com/anchildress1)
+[anchildress1@gmail.com](mailto:anchildress1@gmail.com)

--- a/assets/llms.txt
+++ b/assets/llms.txt
@@ -8,8 +8,8 @@ Allow: /
 Policy: no-training
 Usage: ephemeral-access
 Purpose: browsing, indexing, real-time reference only
-Contact: human@checkmarkdevtools.dev
-Copyright: © 2025 Ashley Childress / CheckMarK DevTools. All rights reserved.
+Contact: anchildress1@gmail.com
+Copyright: © 2025 Ashley Childress. All rights reserved.
 
 # License: Polyform Shield (unless otherwise specified in repository)
 # No AI training, storage, or commercial reuse without written consent.

--- a/docs/CI_GUIDE.md
+++ b/docs/CI_GUIDE.md
@@ -62,7 +62,7 @@ Preserves the original `gh-pages` behavior for forks that do not use Firebase:
 5. **Static Asset Generation**:
    - `index.html` with post listings
    - Individual post pages
-6. **Sitemap Generation**: Runs `render_index_sitemap.py` to create `sitemap.xml`
+6. **Sitemap Generation**: Runs `python -m devto_mirror.site_generation.renderer` to create `index.html` and `sitemap.xml`
 7. **Deployment Preparation**: Assembles all files into `_deploy` directory including:
    - Generated HTML pages
    - robots.txt and llms.txt (processed from templates)
@@ -87,7 +87,7 @@ Preserves the original `gh-pages` behavior for forks that do not use Firebase:
 **Environment Variables**:
 
 - `DEVTO_USERNAME`: Repository variable (required) - Your Dev.to username
-- `SITE_DOMAIN`: Repository variable (optional) - Custom domain (e.g., `crawly.checkmarkdevtools.dev`)
+- `SITE_DOMAIN`: Repository variable (optional) - Custom domain (e.g., `crawly.anchildress1.dev`)
   - If set, overrides GitHub Pages URL construction
   - Falls back to `GH_USERNAME`-based URL if not provided
 - `GH_USERNAME`: Repository variable (required if `SITE_DOMAIN` not set) - Your GitHub username for Pages URLs
@@ -198,7 +198,7 @@ Each workflow uses **least-privilege permissions**:
 
 ```yaml
 permissions:
-  contents: write         # Push incremental state to gh-pages (publish only)
+  contents: write         # Push incremental state to the state branch (mirror-state upstream, gh-pages on forks)
   id-token: write         # OIDC for Workload Identity Federation (publish only)
   security-events: write  # CodeQL results (codeql only)
 ```
@@ -379,7 +379,7 @@ Double-wrapping with `uv run make` breaks the execution context.
 ```yaml
 # ✅ CORRECT - Use uv run for scripts
 - name: Generate site
-  run: uv run python scripts/generate_site.py
+  run: uv run python -m devto_mirror.site_generation.generator
 
 # ✅ CORRECT - Or use make targets that wrap them
 - name: Generate site

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -192,9 +192,14 @@ After forking the repository, configure it for automatic deployment:
    - Choose `gh-pages` branch (created automatically by first workflow run)
    - Your site will be available at `https://yourusername.github.io/devto-mirror`
 
-3. **Run initial workflow**:
+3. **Delete any inherited `gh-pages` branch first**:
+   - Forks copy upstream's branches, so a leftover `gh-pages` carries upstream's `last_run.txt`/`posts_data.json`
+   - Left in place, the first run restores that state, skips your older posts, and republishes stale upstream content (`keep_files: true`)
+   - Delete it so your first run starts clean
+
+4. **Run initial workflow**:
    - Go to Actions → "Deploy Dev.to Mirror to GitHub Pages" → Run workflow
-   - This creates the `gh-pages` branch and deploys your first site
+   - This recreates the `gh-pages` branch and deploys your first site
    - (The "Generate and Publish Dev.to Mirror Site" workflow is the upstream Firebase deploy and only runs for the repo owner)
 
 ### Manual Workflow Triggers

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -42,7 +42,7 @@ This guide covers setting up the Dev.to Mirror project for local development. Th
 5. **Generate your site locally**:
 
    ```bash
-   uv run python scripts/generate_site.py   # Creates HTML files in posts/ directory
+   uv run python -m devto_mirror.site_generation.generator   # Creates HTML files in posts/ and index.html
    ```
 
 ## Environment Variables
@@ -55,7 +55,7 @@ The project uses a `.env` file for local development configuration. This keeps s
 
 **Site URL configuration (one required):**
 
-- `SITE_DOMAIN`: Custom domain (e.g., "crawly.checkmarkdevtools.dev")
+- `SITE_DOMAIN`: Custom domain (e.g., "crawly.anchildress1.dev")
 - `GH_USERNAME`: GitHub username (e.g., "anchildress1") - used if `SITE_DOMAIN` not set
 
 **Optional variables:**
@@ -67,7 +67,7 @@ The project uses a `.env` file for local development configuration. This keeps s
 
 ```bash
 DEVTO_USERNAME=your-username
-SITE_DOMAIN=crawly.checkmarkdevtools.dev
+SITE_DOMAIN=crawly.anchildress1.dev
 FORCE_FULL_REGEN=false
 VALIDATION_MODE=false
 ```
@@ -126,15 +126,16 @@ If any hook fails, the commit is blocked until you fix the issues.
 
 ```plaintext
 devto-mirror/
-├── scripts/                 # Main site generation and utility scripts
-│   ├── generate_site.py    # Core site generation logic
-│   ├── validate_site_generation.py  # Lefthook validation
-│   └── utils.py            # Shared script utilities
-├── src/                    # Python package (AI optimization modules)
-│   └── ai_optimization/    # Content analysis and cross-references
-├── tests/                  # Unit tests
+├── src/devto_mirror/        # Python package (all application code)
+│   ├── core/               # Dev.to API client, sanitization, URL building, run-state, shared templates
+│   ├── ai_optimization/    # JSON-LD schemas, metadata, cross-references, AI sitemap
+│   ├── site_generation/    # generator.py (main pipeline) + renderer.py (index/sitemap)
+│   ├── templates/          # post_template.html
+│   └── tools/              # one-off maintenance helpers
+├── scripts/                # CI helpers (validate_site_generation.py, check_detect_secrets.py, run_pip_audit.py)
+├── tests/                  # Unit tests (unittest, 85% coverage gate)
 ├── docs/                   # Documentation
-└── .env.example           # Environment variable template
+└── .env.example            # Environment variable template
 ```
 
 ## Testing
@@ -187,8 +188,9 @@ After forking the repository, configure it for automatic deployment:
    - Your site will be available at `https://yourusername.github.io/devto-mirror`
 
 3. **Run initial workflow**:
-   - Go to Actions → "Generate and Publish Dev.to Mirror Site" → Run workflow
+   - Go to Actions → "Deploy Dev.to Mirror to GitHub Pages" → Run workflow
    - This creates the `gh-pages` branch and deploys your first site
+   - (The "Generate and Publish Dev.to Mirror Site" workflow is the upstream Firebase deploy and only runs for the repo owner)
 
 ### Manual Workflow Triggers
 
@@ -205,6 +207,6 @@ Trigger workflows manually for testing or immediate updates:
 - Testing changes before they go live
 - Immediate updates after publishing new posts
 - Troubleshooting workflow issues
-- Full site regeneration (via `publish.yaml` with `force_full_regen=true`)
+- Full site regeneration (run your deploy workflow with `force_full_regen=true`)
 
 For detailed explanations of the CI/CD workflows and their technical implementation, see [`CI_GUIDE.md`](CI_GUIDE.md).

--- a/docs/DEV_GUIDE.md
+++ b/docs/DEV_GUIDE.md
@@ -172,7 +172,12 @@ make ai-checks              # Complete validation pipeline
 
 ## GitHub Actions Setup
 
-### Repository Configuration
+There are two deploy paths, and which one you use depends on who you are:
+
+- **Upstream (owner `anchildress1`) → Firebase Hosting** (`publish.yaml`). This is the **primary** deploy: keyless auth via Workload Identity Federation, served at `crawly.anchildress1.dev`. It only runs for the repo owner and needs the Firebase/GCP variables (see [CI_GUIDE.md](./CI_GUIDE.md)).
+- **Forks → GitHub Pages** (`deploy-gh-pages.yml`). The fork-friendly fallback that preserves the original `gh-pages` behavior. **This is the path the setup below covers.**
+
+### Repository Configuration (fork → GitHub Pages)
 
 After forking the repository, configure it for automatic deployment:
 

--- a/docs/MIGRATION_PLAN.md
+++ b/docs/MIGRATION_PLAN.md
@@ -1,5 +1,8 @@
 # AI Optimization Module Migration Plan
 
+> [!NOTE]
+> **Historical artifact — superseded.** This plan tracked an earlier migration to `src/ai_optimization/`. That package was later moved under the project package and now lives at `src/devto_mirror/ai_optimization/`. The `src/ai_optimization/` paths and `from src.ai_optimization import ...` snippets below are out of date — see [DEV_GUIDE.md](./DEV_GUIDE.md) for the current structure. Kept as-is for history.
+
 ## Overview
 
 This document tracks the migration of the monolithic `scripts/ai_optimization.py` file into a proper package structure under `src/ai_optimization/`.


### PR DESCRIPTION
## What & why 📚

The repo moved (`checkmarkdevtools` org → `anchildress1`) and the deploy model flipped — **Firebase Hosting is now primary** (upstream), with **gh-pages as the fork fallback**. The docs still described the old org, the old gh-pages-primary model, and entry-point scripts that no longer exist. This aligns every active doc with what the code actually does.

## README (rewrite, new-dev friendly) 🔧
- Live site → `crawly.anchildress1.dev`; banner uses a relative path (survives transfers)
- **Every badge** org path fixed (`checkmarkdevtools` → `anchildress1`); **added a Firebase Hosting badge** — no badges lost
- New sections: **Tech Stack**, **Architecture** (validated Mermaid diagram of the two deploy paths), **Project Structure**, **Configuration** table (fork vs upstream vars, incl. opt-in `FIREBASE_WEB_CONFIG`)
- Corrected the inverted topology and the **fork setup workflow** ("Deploy Dev.to Mirror to GitHub Pages", not the upstream Firebase one)

## Guides
- **DEV_GUIDE / CI_GUIDE**: replaced nonexistent `scripts/generate_site.py` and `render_index_sitemap.py` with the real module entry points (`devto_mirror.site_generation.generator`/`renderer`); fixed the package tree (`src/devto_mirror/`), the fork setup workflow name, stale domains, and a permissions comment
- **MIGRATION_PLAN**: added a *superseded* banner (historical artifact — body untouched)

## Brand/contact scrub
- **SECURITY.md / LICENSE / assets/llms.txt**: old `checkmarkdevtools` brand + `human@checkmarkdevtools.dev` → `anchildress1@gmail.com`

## Left intentionally untouched
- `CHANGELOG.md`, dated `docs/implementations/*`, `COMPLEXITY_REFACTORING.md`, `ENV_FIXES.md` — historical artifacts
- Test fixtures using `crawly.checkmarkdevtools.dev` — stable mock data
- `sonar-project.properties`, `.vscode/settings.json` — repo config (not docs; out of scope)

## Verified ✅
- `make ai-checks` green (docs-only; coverage 88.74%)
- Mermaid diagram validated (`valid: true`)
- No remaining `checkmarkdevtools` refs in active docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)